### PR TITLE
Fix link to license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ $ phpunit
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+The MIT License (MIT). Please see [License File](LICENSE) for more information.


### PR DESCRIPTION
The anchor was referencing the file with a `.md` extension while the actual file uses no extension at all.
